### PR TITLE
[FIX] | Add dispose method, implement Equatable, add dependency and inject attributes to do easy testing.

### DIFF
--- a/lib/features/forget_password/presentation/view_model/forget_password_cubit/forget_password_cubit.dart
+++ b/lib/features/forget_password/presentation/view_model/forget_password_cubit/forget_password_cubit.dart
@@ -1,4 +1,5 @@
 import 'package:easy_localization/easy_localization.dart';
+import 'package:equatable/equatable.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:injectable/injectable.dart';
@@ -22,6 +23,12 @@ class ForgetPasswordCubit extends Cubit<ForgetPasswordState> {
   final GlobalKey<FormState> formKey = GlobalKey<FormState>();
   final TextEditingController emailController = TextEditingController();
   ValueNotifier<bool> valid = ValueNotifier(false);
+
+  @override
+  Future<void> close() {
+    emailController.dispose();
+    return super.close();
+  }
 
   void doIntent(ForgetPasswordAction action) {
     switch (action) {

--- a/lib/features/forget_password/presentation/view_model/forget_password_cubit/forget_password_cubit.dart
+++ b/lib/features/forget_password/presentation/view_model/forget_password_cubit/forget_password_cubit.dart
@@ -1,10 +1,8 @@
-import 'package:easy_localization/easy_localization.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:injectable/injectable.dart';
 import '../../../../../core/base/base_state.dart';
-import '../../../../../core/utils/l10n/locale_keys.g.dart';
 import '../../../../../core/utils/validation/validator.dart';
 import '../../../../../domain/core/api_result.dart';
 import '../../../../../domain/entities/forget_password_entity.dart';
@@ -15,10 +13,11 @@ part 'forget_password_state.dart';
 @injectable
 class ForgetPasswordCubit extends Cubit<ForgetPasswordState> {
   final ForgetPasswordUseCase forgetPasswordUseCase;
-  final Validator validator = Validator();
+  final Validator validator;
 
-  ForgetPasswordCubit(this.forgetPasswordUseCase)
-      : super(ForgetPasswordState(baseState: BaseInitialState()));
+  ForgetPasswordCubit(this.forgetPasswordUseCase, {Validator? validator})
+      : validator = validator ?? Validator(),
+        super(ForgetPasswordState(baseState: BaseInitialState()));
 
   final GlobalKey<FormState> formKey = GlobalKey<FormState>();
   final TextEditingController emailController = TextEditingController();
@@ -72,13 +71,6 @@ class ForgetPasswordCubit extends Cubit<ForgetPasswordState> {
       valid.value = true;
     } else {
       valid.value = false;
-      emit(
-        state.copyWith(
-          baseState: BaseErrorState(
-            errorMessage: LocaleKeys.Error_EmailNotValid.tr(),
-          ),
-        ),
-      );
     }
   }
 }

--- a/lib/features/forget_password/presentation/view_model/forget_password_cubit/forget_password_state.dart
+++ b/lib/features/forget_password/presentation/view_model/forget_password_cubit/forget_password_state.dart
@@ -1,15 +1,18 @@
 part of 'forget_password_cubit.dart';
 
-class ForgetPasswordState {
+class ForgetPasswordState extends Equatable {
   final BaseState baseState;
 
-  ForgetPasswordState({required this.baseState});
+  const ForgetPasswordState({required this.baseState});
 
   ForgetPasswordState copyWith({BaseState? baseState}) {
     return ForgetPasswordState(
       baseState: baseState ?? this.baseState,
     );
   }
+
+  @override
+  List<Object?> get props => [baseState];
 }
 
 // actions

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -217,6 +217,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.0.2"
+  equatable:
+    dependency: "direct main"
+    description:
+      name: equatable
+      sha256: "567c64b3cb4cf82397aac55f4f0cbd3ca20d77c6c03bedbc4ceaddc08904aef7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.7"
   fake_async:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,7 @@ dependencies:
   cupertino_icons: ^1.0.8
   dio: ^5.8.0+1
   easy_localization: ^3.0.7+1
+  equatable: ^2.0.7
   flutter:
     sdk: flutter
   flutter_bloc: ^9.0.0


### PR DESCRIPTION
- Added close() method in ForgetPasswordCubit to dispose of emailController to prevent memory leak.
- Extended ForgetPasswordState with Equatable for state comparison.
- Added equatable dependency to pubspec.yaml.
- inject Validator for easier testing and remove error state emission 